### PR TITLE
fix: enable Sentry structured logs for Python backend

### DIFF
--- a/api/main.py
+++ b/api/main.py
@@ -37,6 +37,7 @@ def filter_transactions(event, hint):
 # Initialize Sentry with integrations and logging
 sentry_sdk.init(
     dsn="https://b8233ed9639fc2fa0e0e5b1727ea893a@o673219.ingest.us.sentry.io/4508087188455424",
+    enable_logs=True,  # Enable Sentry structured logs
     integrations=[
         FastApiIntegration(),
         StarletteIntegration(),

--- a/api/requirements.txt
+++ b/api/requirements.txt
@@ -1,6 +1,6 @@
 fastapi
 uvicorn
-sentry-sdk[fastapi]==2.19.2
+sentry-sdk[fastapi]>=2.35.0
 supabase>=2.10.0
 aiohttp
 httpx

--- a/supabase/functions/create-order/index.ts
+++ b/supabase/functions/create-order/index.ts
@@ -2,8 +2,11 @@ import * as Sentry from 'npm:@sentry/deno@^10.0.0'
 import { createClient } from 'npm:@supabase/supabase-js@2'
 
 // Initialize Sentry (v10 - updated from v9)
+// Use environment variable for DSN to allow different configs per environment
+const sentryDsn = Deno.env.get('SENTRY_DSN') || 'https://2063cf707cf29518cc1016545dfc0b0a@o673219.ingest.us.sentry.io/4510269126279168'
+
 Sentry.init({
-  dsn: 'https://2063cf707cf29518cc1016545dfc0b0a@o673219.ingest.us.sentry.io/4510269126279168',
+  dsn: sentryDsn,
   defaultIntegrations: false,
   tracesSampleRate: 1.0,
   profilesSampleRate: 1.0,
@@ -19,9 +22,33 @@ Sentry.setTag('region', Deno.env.get('SB_REGION') || 'unknown')
 Sentry.setTag('execution_id', Deno.env.get('SB_EXECUTION_ID') || 'unknown')
 
 // Create Supabase client using built-in environment variables
-// These are automatically provided by Supabase Edge Runtime
-const supabaseUrl = Deno.env.get('SUPABASE_URL')!
-const supabaseServiceKey = Deno.env.get('SUPABASE_SERVICE_ROLE_KEY')!
+// Supabase automatically provides SUPABASE_URL in edge runtime
+const supabaseUrl = Deno.env.get('SUPABASE_URL')
+const supabaseServiceKey = Deno.env.get('SUPABASE_SERVICE_ROLE_KEY')
+
+// Check for required environment variables
+if (!supabaseUrl || !supabaseServiceKey) {
+  const errorMsg = 'Missing required environment variables'
+  console.error('❌ Configuration error:', {
+    hasSupabaseUrl: !!supabaseUrl,
+    hasServiceKey: !!supabaseServiceKey
+  })
+  
+  if (Sentry.logger) {
+    Sentry.logger.error('Edge function configuration error', {
+      error: errorMsg,
+      hasSupabaseUrl: !!supabaseUrl,
+      hasServiceKey: !!supabaseServiceKey
+    })
+  }
+  
+  // Even if config is wrong, we can still send this error to Sentry before failing
+  Sentry.captureException(new Error(errorMsg))
+  await Sentry.flush(2000)
+  
+  throw new Error(errorMsg)
+}
+
 const supabase = createClient(supabaseUrl, supabaseServiceKey)
 
 interface OrderItem {

--- a/supabase/functions/create-order/index.ts
+++ b/supabase/functions/create-order/index.ts
@@ -2,11 +2,8 @@ import * as Sentry from 'npm:@sentry/deno@^10.0.0'
 import { createClient } from 'npm:@supabase/supabase-js@2'
 
 // Initialize Sentry (v10 - updated from v9)
-// Use environment variable for DSN to allow different configs per environment
-const sentryDsn = Deno.env.get('SENTRY_DSN') || 'https://2063cf707cf29518cc1016545dfc0b0a@o673219.ingest.us.sentry.io/4510269126279168'
-
 Sentry.init({
-  dsn: sentryDsn,
+  dsn: 'https://2063cf707cf29518cc1016545dfc0b0a@o673219.ingest.us.sentry.io/4510269126279168',
   defaultIntegrations: false,
   tracesSampleRate: 1.0,
   profilesSampleRate: 1.0,


### PR DESCRIPTION
- Add enable_logs=True parameter to sentry_sdk.init()
- Allows Python logs to appear in Sentry Logs view
- Existing logger.info() calls with extra={} now send searchable log attributes
- Fixes issue where only errors/traces were visible, not logs

- Fixing deno logs too

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Enables Sentry structured logging in Python, upgrades the SDK, and refactors the create-order edge function to Sentry v10 with env-configured DSN, validation, structured logs, and distributed tracing.
> 
> - **Backend (Python FastAPI)**:
>   - Enable Sentry structured logging via `enable_logs=True` in `api/main.py`.
> - **Edge Function (`supabase/functions/create-order/index.ts`)**:
>   - Migrate to Sentry v10 init with `enableLogs`, `debug`, and DSN from `SENTRY_DSN` env.
>   - Add env var validation with early failure, Sentry capture/flush on config errors.
>   - Implement distributed tracing using `sentry-trace`/`baggage` with `Sentry.continueTrace()` and `startSpan()` around DB operations.
>   - Add structured logs, breadcrumbs, and explicit success/error handling with JSON responses.
>   - Set standard tags (`service`, `region`, `execution_id`).
> - **Dependencies**:
>   - Bump Python `sentry-sdk[fastapi]` to `>=2.35.0` in `api/requirements.txt`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b50cee138f10c3eac082f735308b7c953c82cb5c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->