### PR TITLE
Remove Sentry tunnel configuration from frontend and backend

### DIFF
--- a/api/main.py
+++ b/api/main.py
@@ -12,7 +12,6 @@ from fastapi.middleware.cors import CORSMiddleware
 from fastapi.staticfiles import StaticFiles
 from urllib.parse import urlparse
 import aiohttp
-import json
 from supabase import create_client, Client
 from dotenv import load_dotenv
 
@@ -375,84 +374,6 @@ async def trigger_error(request: Request):
     })
     
     division_by_zero = 1 / 0
-
-
-# Replace with your actual Sentry host and project IDs
-SENTRY_HOST = "o673219.ingest.us.sentry.io"
-SENTRY_PROJECT_IDS = ["4508059881242624"]
-
-@app.post("/tunnel")
-async def sentry_tunnel(request: Request):
-    try:
-        # Read the raw bytes from the request body
-        envelope_bytes = await request.body()
-        
-        # Decode bytes to string and split into lines
-        envelope = envelope_bytes.decode('utf-8')
-        pieces = envelope.split('\n')
-        header_str = pieces[0]
-        
-        # Parse the envelope header as JSON
-        header = json.loads(header_str)
-        dsn = header.get('dsn', '')
-        
-        # Log the received DSN
-        logger.debug("Received Sentry tunnel request", extra={
-            "dsn": dsn,
-            "envelope_size": len(envelope_bytes)
-        })
-        
-        # Parse the DSN to extract hostname and project ID
-        dsn_parsed = urlparse(dsn)
-        hostname = dsn_parsed.hostname
-        project_id = dsn_parsed.path.strip('/')
-        
-        # Validate the hostname and project ID
-        if hostname != SENTRY_HOST:
-            logger.error("Invalid Sentry hostname", extra={
-                "received_hostname": hostname,
-                "expected_hostname": SENTRY_HOST
-            })
-            raise Exception(f"Invalid Sentry hostname: {hostname}")
-        
-        if not project_id or project_id not in SENTRY_PROJECT_IDS:
-            logger.error("Invalid Sentry project ID", extra={
-                "received_project_id": project_id,
-                "allowed_project_ids": SENTRY_PROJECT_IDS
-            })
-            raise Exception(f"Invalid Sentry project ID: {project_id}")
-        
-        # Construct the upstream Sentry URL
-        upstream_sentry_url = f"https://{SENTRY_HOST}/api/{project_id}/envelope/"
-        
-        logger.debug("Forwarding envelope to Sentry", extra={
-            "upstream_url": upstream_sentry_url,
-            "project_id": project_id
-        })
-        
-        # Forward the envelope to Sentry
-        async with aiohttp.ClientSession() as session:
-            async with session.post(
-                upstream_sentry_url,
-                data=envelope_bytes,
-                headers={'Content-Type': 'application/x-sentry-envelope'}
-            ) as resp:
-                if resp.status != 200:
-                    logger.error("Upstream Sentry returned error", extra={
-                        "status_code": resp.status,
-                        "project_id": project_id
-                    })
-                    raise Exception(f"Upstream Sentry returned status {resp.status}")
-        
-        logger.debug("Successfully forwarded to Sentry", extra={"project_id": project_id})
-        # Return success response
-        return Response(status_code=200)
-    except Exception as e:
-        logger.error("Error tunneling to Sentry", extra={
-            "error": str(e),
-            "error_type": type(e).__name__
-        })
-        return JSONResponse(content={'error': 'Error tunneling to Sentry'}, status_code=500)
 
 if __name__ == "__main__":
     import uvicorn

--- a/src/main.js
+++ b/src/main.js
@@ -33,12 +33,6 @@ const supabaseAnonKey = import.meta.env.VITE_SUPABASE_ANON_KEY || 'eyJhbGciOiJIU
 
 export const supabase = createClient(supabaseUrl, supabaseAnonKey)
 
-// Determine the tunnel URL based on the environment
-const isProduction = import.meta.env.PROD
-const tunnelUrl = isProduction
-  ? 'https://vue-store-pinia.onrender.com/tunnel'
-  : 'http://localhost:8000/tunnel'
-
 Sentry.init({
   app,
   dsn: import.meta.env.PUBLIC_SENTRY_DSN || 'https://4a85c87c7894458aff8578d0f2d2dd89@o673219.ingest.us.sentry.io/4508059881242624',
@@ -58,7 +52,6 @@ Sentry.init({
       errors: true,
     }),
   ],
-  tunnel: tunnelUrl, // Use the determined tunnel URL
   sendDefaultPii: true, // Enable sending of headers and cookies
   enableLogs: true, // Enable Sentry structured logs
   tracesSampleRate: 1.0,


### PR DESCRIPTION
- Remove tunnel URL configuration from frontend (src/main.js)
- Remove /tunnel endpoint from backend API (api/main.py)
- Remove unused json import from backend
- Session replays and errors now sent directly to Sentry

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Removes the Sentry tunnel endpoint and frontend tunnel config so events/replays go directly to Sentry.
> 
> - **Backend**:
>   - Remove `POST /tunnel` endpoint and related `SENTRY_HOST`/`SENTRY_PROJECT_IDS` logic in `api/main.py`.
>   - Drop unused `json` import.
> - **Frontend**:
>   - Remove tunnel URL selection and `tunnel` option from `Sentry.init` in `src/main.js` to send data directly via DSN.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 634199a54d130bfef6efcab72627de29e003c550. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->